### PR TITLE
Remove slam toolbox from cmake, no need to call out

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(neo_simulation2)
 find_package(ament_cmake REQUIRED)
 find_package(nav2_bringup REQUIRED)
 find_package(navigation2 REQUIRED)
-find_package(slam_toolbox REQUIRED)
-
 
 install(DIRECTORY launch
   configs


### PR DESCRIPTION
and causes issues if  I dont have a copy installed in my current workspace paths (which should not be required to use simulation)